### PR TITLE
Implementation of Deep Belief Networks

### DIFF
--- a/src/Boltzmann.jl
+++ b/src/Boltzmann.jl
@@ -8,7 +8,6 @@ export BernoulliRBM,
        transform,
        generate,
        components
-       
 
 include("rbm.jl")
 include("dbn.jl")

--- a/src/dbn.jl
+++ b/src/dbn.jl
@@ -1,23 +1,32 @@
-# This is a DBN where the first layer is a Gaussian-Bernoulli RBM and all the other
-# layers are Bernoulli RBMs.
-type DBN
-  rbms::Vector{Union{BernoulliRBM, GRBM}}
+# This is a DBN where the first layer is a either a Bernoulli or a 
+# Gaussian-Bernoulli RBM and all the other layers are Bernoulli RBMs.
+immutable DBN
+  rbms::Vector{Union(BernoulliRBM, GRBM)}
 
-  DBN(dims::Vector{Int}) = begin
-    rbms = Array(Union{BernoulliRBM, GRBM}}, 0)
+  DBN(dims::Vector{Int}; vis_type=GRBM) = begin
+  rbms = Array(Union(BernoulliRBM, GRBM), 0)
+  if vis_type == GRBM
     push!(rbms, GRBM(dims[1],dims[2]))
-    for k=2:length(dims)-1
-      push!(rbms, BernoulliRBM(dims[k],dims[k+1]))
+  else
+    if vis_type == BernoulliRBM
+      push!(rbms, BernoulliRBM(dims[1],dims[2]))
+    else 
+      error("vis_type not supported")
     end
-    new(rbms)
   end
+  for k=2:length(dims)-1
+    push!(rbms, BernoulliRBM(dims[k],dims[k+1]))
+  end
+  new(rbms)
+end
+
 end
 
 function mh_at_layer(dbn::DBN, batch::Array{Float64, 2}, layer::Int)
   hiddens = Array(Array{Float64, 2}, layer)
   hiddens[1] = mean_hiddens(dbn.rbms[1], batch)
   for k=2:layer
-    hiddens[k] = mh(dbn.rbms[k], hiddens[k-1])
+    hiddens[k] = mean_hiddens(dbn.rbms[k], hiddens[k-1])
   end
   hiddens[end]
 end
@@ -26,11 +35,10 @@ function fit(dbn::DBN, X::Mat{Float64}; lr=0.1, n_iter=10, batch_size=100, n_gib
   n_samples = size(X,2)
   n_batches = int(ceil(n_samples / batch_size))
   for k = 1:length(dbn.rbms)
-    println("Training layer $k/$(length(dbn.rbms))")
     w_buf = zeros(size(dbn.rbms[k].W))
     for itr=1:n_iter
+      info("Layer $(k), iteration $(itr)")
       for i=1:n_batches
-        mod(i,100) == 0 ? info("Iteration $(itr): fitting batch $(i)/$(n_batches)") : nothing
         batch = X[:, ((i-1)*batch_size + 1):min(i*batch_size, end)]
         input = k == 1 ? batch : mh_at_layer(dbn, batch, k)
         fit_batch!(dbn.rbms[k], input, buf=w_buf, n_gibbs=n_gibbs)

--- a/test/testdbn.jl
+++ b/test/testdbn.jl
@@ -1,0 +1,9 @@
+using HDF5, Boltzmann
+
+f = h5open("/Users/jfsantos/.julia/v0.3/Mocha/examples/mnist/data/train.hdf5")
+data = read(f["data"])
+X = convert(Matrix{Float64}, reshape(squeeze(data, 3), (28*28, 60000)))
+
+dbn = DBN([784, 100, 100]; vis_type=BernoulliRBM)
+fit(dbn, X)
+


### PR DESCRIPTION
This is a cleaned up version of my DBN implementation using the RBMs in Boltzmann.jl. For now it is a really simple extension, as it justs adds a new type `DBN` and a function to fit it, as well as a helper function to compute the mean of the hiddens at a given layer. The user can only change the type of the first RBM because in most of the applications I've seen all the upper layers are Bernoulli RBMs, but this can be easily changed if needed.

I also added an example that uses the MNIST dataset to train it. The HDF5 file is generated by [this script](https://github.com/pluskid/Mocha.jl/blob/master/examples/mnist/get-mnist.sh) from the Mocha.jl package. I think we could test it with a simpler dataset and add that test at a separate folder (e.g., `examples/`).
