### PR TITLE
Fixed `axpy!` call in sparsity calculations.

### DIFF
--- a/src/conditional.jl
+++ b/src/conditional.jl
@@ -195,11 +195,11 @@ function grad_apply_sparsity!(rbm::ConditionalRBM, X::Mat,
                   throw(ArgumentError("If :sparsity_cost is used, :sparsity_target should also be defined")))
     curr_sparsity = mean(hid_means(rbm, vis))
     penalty = cost * (curr_sparsity - target)
-    axpy!(-penalty, dW, dW)
-    axpy!(-penalty, dA, dA)
-    axpy!(-penalty, dB, dB)
-    axpy!(-penalty, db, db)
-    axpy!(-penalty, dc, dc)
+    axpy!(-penalty, ones(size(dW)), dW)
+    axpy!(-penalty, ones(size(dA)), dA)
+    axpy!(-penalty, ones(size(dB)), dB)
+    axpy!(-penalty, ones(size(db)), db)
+    axpy!(-penalty, ones(size(dc)), dc)
 end
 
 

--- a/src/conditional.jl
+++ b/src/conditional.jl
@@ -183,7 +183,7 @@ function grad_apply_weight_decay!(rbm::ConditionalRBM,
 end
 
 
-function grad_apply_sparsity!(rbm::ConditionalRBM, X::Mat,
+function grad_apply_sparsity!{T}(rbm::ConditionalRBM{T}, X::Mat,
                                  dtheta::Tuple, ctx::Dict)
     # The sparsity constraint should only drive the weights
     # down when the mean activation of hidden units is higher
@@ -194,12 +194,12 @@ function grad_apply_sparsity!(rbm::ConditionalRBM, X::Mat,
     target = @get(ctx, :sparsity_target,
                   throw(ArgumentError("If :sparsity_cost is used, :sparsity_target should also be defined")))
     curr_sparsity = mean(hid_means(rbm, vis))
-    penalty = cost * (curr_sparsity - target)
-    axpy!(-penalty, ones(size(dW)), dW)
-    axpy!(-penalty, ones(size(dA)), dA)
-    axpy!(-penalty, ones(size(dB)), dB)
-    axpy!(-penalty, ones(size(db)), db)
-    axpy!(-penalty, ones(size(dc)), dc)
+    penalty = T(cost * (curr_sparsity - target))
+    add!(dW, -penalty)
+    add!(dA, -penalty)
+    add!(dB, -penalty)
+    add!(db, -penalty)
+    add!(dc, -penalty)
 end
 
 

--- a/src/rbm.jl
+++ b/src/rbm.jl
@@ -308,9 +308,9 @@ function grad_apply_sparsity!(rbm::RBM, X::Mat,
     target = @get(ctx, :sparsity_target, throw(ArgumentError("If :sparsity_cost is used, :sparsity_target should also be defined")))
     curr_sparsity = mean(hid_means(rbm, X))
     penalty = cost * (curr_sparsity - target)
-    axpy!(-penalty, dW, dW)
-    axpy!(-penalty, db, db)
-    axpy!(-penalty, dc, dc)
+    axpy!(-penalty, ones(size(dW)), dW)
+    axpy!(-penalty, ones(size(db)), db)
+    axpy!(-penalty, ones(size(dc)), dc)
 end
 
 

--- a/src/rbm.jl
+++ b/src/rbm.jl
@@ -298,7 +298,7 @@ function grad_apply_weight_decay!(rbm::RBM, X::Mat,
 
 end
 
-function grad_apply_sparsity!(rbm::RBM, X::Mat,
+function grad_apply_sparsity!{T}(rbm::RBM{T}, X::Mat,
                               dtheta::Tuple, ctx::Dict)
     # The sparsity constraint should only drive the weights
     # down when the mean activation of hidden units is higher
@@ -307,10 +307,10 @@ function grad_apply_sparsity!(rbm::RBM, X::Mat,
     cost = @get_or_return(ctx, :sparsity_cost, nothing)
     target = @get(ctx, :sparsity_target, throw(ArgumentError("If :sparsity_cost is used, :sparsity_target should also be defined")))
     curr_sparsity = mean(hid_means(rbm, X))
-    penalty = cost * (curr_sparsity - target)
-    axpy!(-penalty, ones(size(dW)), dW)
-    axpy!(-penalty, ones(size(db)), db)
-    axpy!(-penalty, ones(size(dc)), dc)
+    penalty = T(cost * (curr_sparsity - target))
+    add!(dW, -penalty)
+    add!(db, -penalty)
+    add!(dc, -penalty)
 end
 
 
@@ -378,7 +378,7 @@ docstrings/code for details.
 
 NOTE: this function is incremental, so one can, for example, run it for
 10 epochs, then inspect the model, then run it for 10 more epochs
-and check the difference. 
+and check the difference.
 """
 function fit{T}(rbm::RBM{T}, X::Mat, opts = Dict{Any,Any}())
     @assert minimum(X) >= 0 && maximum(X) <= 1

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -152,3 +152,9 @@ function ensure_type(newT::DataType, A::AbstractArray)
         A
     end
 end
+
+function add!{T}(X::Array{T}, inc::T)
+    @simd for i=1:length(X)
+        @inbounds X[i] += inc
+    end
+end


### PR DESCRIPTION
The existing sparsity calculations were doing `axpy!(-penalty, dx, dx)` (ie: `dx -= dx * penalty`) which I believe should be `dx -= penalty` or `axpy!(-penalty, ones(size(dx)), dx)`.