### PR TITLE
Error in tests for utils on Julia 0.5

### DIFF
--- a/src/test.jl
+++ b/src/test.jl
@@ -283,6 +283,7 @@ function compare{T,V,H}(rbm::AbstractRBM{T,V,H}, options::Dict...; input_size=-1
 
     X = generate_dataset(T, n_vis; n_obs=n_obs)
     args = [map(opt -> (X, opt), options)...]
+    deepcopy(rbm)
     rbms = map(i -> deepcopy(rbm), 1:length(args))
     return compare(fit, rbms, args)
 end


### PR DESCRIPTION
Currently `Pkg.test("Boltzmann")` fails with pretty interesting error:

> ERROR: LoadError: LoadError: TypeError: _collect: in typeassert, expected Boltzmann.RBM{Float64,Distributions.Normal,Distributions.Bernoulli}, got Boltzmann.RBM{Float64,Distributions.Normal,Distributions.Bernoulli}

This message to the line 286:

    rbms = map(i -> deepcopy(rbm), 1:length(args))

which is supposed to simply create 2 clones of RBM. Strangely enough, error disappears if I add call:

    deepcopy(rbm)

just before the line described. 

This sound pretty much like a bug in Julia itself (I'm on 0.5.0 currently), but I wasn't able to create a minimal reproducible example to submit an issue. @Rory-Finnegan maybe you know some details of what may be going here or ideas how to make a minimal example?